### PR TITLE
chore: renovate/dependabotのPRを無視するように修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,11 +6,19 @@ const ctx = github.context
 async function run(): Promise<void> {
   try {
     const token = core.getInput('GITHUB_TOKEN', {required: true})
-    const author = ctx.payload.pull_request?.user.login
 
-    if (!author) {
-      throw new Error('Fail to get PR author.')
+    const pull_request = ctx.payload.pull_request
+    if (!pull_request) {
+      throw new Error('This action can only be run on pull_request')
     }
+
+    const ref = pull_request.head.ref
+    if (ref.startsWith('dependabot') || ref.startsWith('renovate')) {
+        core.info('This PR is created by bot, skip assigning')
+        return
+    }
+
+    const author = pull_request.user.login
 
     const octokit = github.getOctokit(token)
 


### PR DESCRIPTION
## 修正内容

SSIA.

## 修正理由

ボットがPRを作成した際にユーザが見つからずエラーが出ていた為。
![スクリーンショット 2025-01-06 10 35 11](https://github.com/user-attachments/assets/3759f97b-749f-4f42-94f7-b54b8a9e1314)

## 経緯

下記PRでbotを無視する変更を加えましたが、これを各リポジトリで個別対応するのは大変なので
actionを変更することにしました。

- https://github.com/400f/hotel/pull/87#issue-2769849160

## 検証

実際に運用して確認します。
