### PR TITLE
fix: 早期リターンはawait promiseを返す

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ async function run(): Promise<void> {
     const ref = pull_request.head.ref
     if (ref.startsWith('dependabot') || ref.startsWith('renovate')) {
         core.info('This PR is created by bot, skip assigning')
-        return
+        return await Promise.resolve()
     }
 
     const author = pull_request.user.login
@@ -36,7 +36,7 @@ async function run(): Promise<void> {
 
     if (pullRequest.assignee) {
       core.warning('This PR has already been assigned')
-      return
+      return await Promise.resolve()
     }
 
     await octokit.issues.addAssignees({


### PR DESCRIPTION
## 変更内容

SSIA.
下記PRの修正
- #8 

## 変更理由

まだエラーが出ていたため、こちらの修正になります。
![スクリーンショット 2025-01-14 17 56 14](https://github.com/user-attachments/assets/e62f06b6-d95e-469f-a9c9-6ce8bc874856)


早期リターンが適切に行われていなかったことが原因でエラーが出たと考えたため一旦試しで入れます。🙏
エラーが出続けるようなら戻します。

[return promiseとreturn await promiseの違い](https://zenn.dev/uhyo/articles/return-await-promise)


