### PR TITLE
テストワークフローのPATをGITHUB_TOKENに置き換え

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
       - uses: ./
         with:
-          GITHUB_TOKEN: ${{ secrets.PAT_REPO }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- テストワークフロー (`.github/workflows/test.yml`) で使用していた classic PAT (`secrets.PAT_REPO`) を廃止
- GitHub Actions 自動発行の `secrets.GITHUB_TOKEN` に移行
- `permissions` に `pull-requests: write` を追加し、最小権限の原則に沿った権限付与に変更

## Background
PAT撲滅委員会からの依頼対応。このアクションが使用する GitHub API は `GITHUB_TOKEN` + `pull-requests: write` で動作するため、classic PAT は不要。

ref: https://github.com/400f/action-assign-reviewers/pull/21

## Post-merge TODO
- [ ] リポジトリの Settings > Secrets から `PAT_REPO` を削除